### PR TITLE
tidy.brmsfit() does not recognize conf.level

### DIFF
--- a/R/brms_tidiers.R
+++ b/R/brms_tidiers.R
@@ -226,7 +226,7 @@ tidy.brmsfit <- function(x, parameters = NA,
     probs <- c((1 - conf.level) / 2, 1 - (1 - conf.level) / 2)
     if (conf.method == "HPDinterval") {
       out[, c("conf.low", "conf.high")] <-
-          coda::HPDinterval(coda::as.mcmc(samples, prob=conf.level))
+          coda::HPDinterval(coda::as.mcmc(samples), prob=conf.level)
     } else {
       out[, c("conf.low", "conf.high")] <-
         t(apply(samples, 2, stats::quantile, probs = probs))


### PR DESCRIPTION
For `conf.method = "HPDinterval"`, argument `conf.level` was not recognized due to a small typo.