### PR TITLE
Correct docs for tidy.lme

### DIFF
--- a/R/nlme_tidiers.R
+++ b/R/nlme_tidiers.R
@@ -49,11 +49,12 @@
 #'
 #' @rdname nlme_tidiers
 #'
-#' @param effects Either "fixed" or "random" (default) or "fixed"
+#' @param effects One or more of "ran_pars", "fixed", "ran_vals", and/or
+#'   "ran_coefs".
 #'
 #' @return \code{tidy} returns one row for each estimated effect, either
 #' random or fixed depending on the \code{effects} parameter. If
-#' \code{effects = "ran_vals"} (or \code{"random"}), it contains the columns
+#' \code{effects = "ran_vals"} (or \code{"ran_pars"}), it contains the columns
 #'   \item{group}{the group within which the random effect is being estimated}
 #'   \item{level}{level within group}
 #'   \item{term}{term being estimated}

--- a/man/lme4_tidiers.Rd
+++ b/man/lme4_tidiers.Rd
@@ -46,7 +46,7 @@
 
 \item{debug}{print debugging output?}
 
-\item{...}{extra arguments (not used)}
+\item{...}{Additional arguments (passed to \code{confint.merMod} for \code{tidy}; \code{augment_columns} for \code{augment}; ignored for \code{glance})}
 
 \item{data}{original data this was fitted on; if not given this will
 attempt to be reconstructed}

--- a/man/nlme_tidiers.Rd
+++ b/man/nlme_tidiers.Rd
@@ -24,7 +24,8 @@
 \item{x}{An object of class \code{lme}, such as those from \code{lme}
 or \code{nlme}}
 
-\item{effects}{Either "random" (default) or "fixed"}
+\item{effects}{One or more of "ran_pars", "fixed", "ran_vals", and/or
+"ran_coefs".}
 
 \item{scales}{scales on which to report the variables: for random effects, the choices are \sQuote{"sdcor"} (standard deviations and correlations: the default if \code{scales} is \code{NULL}) or \sQuote{"vcov"} (variances and covariances). \code{NA} means no transformation, appropriate e.g. for fixed effects.}
 
@@ -45,7 +46,7 @@ The structure depends on the method chosen.
 
 \code{tidy} returns one row for each estimated effect, either
 random or fixed depending on the \code{effects} parameter. If
-\code{effects = "random"}, it contains the columns
+\code{effects = "ran_vals"} (or \code{"ran_pars"}), it contains the columns
   \item{group}{the group within which the random effect is being estimated}
   \item{level}{level within group}
   \item{term}{term being estimated}


### PR DESCRIPTION
There was a typo in the argument description for the `effects` argument for `tidy.lme()`.  It's not fully clear to me if the modification on new line 57 is completely correct, but it's at least closer.