### PR TITLE
add nobs to lme4 glance via finish_glance and update tests accordingly

### DIFF
--- a/R/lme4_tidiers.R
+++ b/R/lme4_tidiers.R
@@ -401,6 +401,7 @@ augment.merMod <- function(x, data = stats::model.frame(x), newdata, ...) {
 #' @rdname lme4_tidiers
 #'
 #' @return \code{glance} returns one row with the columns
+#'   \item{nobs}{the number of observations}
 #'   \item{sigma}{the square root of the estimated residual variance}
 #'   \item{logLik}{the data's log-likelihood under the model}
 #'   \item{AIC}{the Akaike Information Criterion}

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -138,7 +138,8 @@ finish_glance <- function(ret = dplyr::tibble(), x) {
   }
 
   newvals <- dplyr::tibble(
-    sigma = tfun(sigma(x)),
+    nobs = tfun(stats::nobs(x)),
+    sigma = tfun(stats::sigma(x)),
     logLik = tfun(as.numeric(stats::logLik(x))),
     AIC = tfun(stats::AIC(x)),
     BIC = tfun(stats::BIC(x)),
@@ -166,7 +167,7 @@ f2 <- function(ret = data.frame(), x, skip_funs = character(0)) {
 
   stopifnot(length(ret) == 0 || nrow(ret) == 1)
 
-  funs <- c("logLik", "AIC", "BIC", "deviance", "df.residual")
+  funs <- c("nobs", "logLik", "AIC", "BIC", "deviance", "df.residual")
   funs <- setdiff(funs, skip_funs)
 
   newvals <- lapply(funs, function(f) as.numeric(tfun(get(f, "package:stats"))))

--- a/man/lme4_tidiers.Rd
+++ b/man/lme4_tidiers.Rd
@@ -100,6 +100,7 @@ are values from the response object within the model (of type
 ".offset", ".sqrtXwt", ".sqrtrwt", ".eta"}.
 
 \code{glance} returns one row with the columns
+  \item{nobs}{the number of observations}
   \item{sigma}{the square root of the estimated residual variance}
   \item{logLik}{the data's log-likelihood under the model}
   \item{AIC}{the Akaike Information Criterion}

--- a/tests/testthat/test-lme4.R
+++ b/tests/testthat/test-lme4.R
@@ -44,7 +44,7 @@ context("lme4 models")
       nAGQ = 0
     )
     ggm <- broom::glance(gm)
-    expect_equal(names(ggm), c("sigma", "logLik", "AIC", "BIC", "deviance", "df.residual"))
+    expect_equal(names(ggm), c("nobs", "sigma", "logLik", "AIC", "BIC", "deviance", "df.residual"))
     td <- tidy(gm)
     expect_equal(
       names(td),
@@ -72,7 +72,7 @@ context("lme4 models")
       start = startvec, nAGQ = 0L
     )
     gnm <- broom::glance(nm)
-    expect_equal(names(gnm), c("sigma", "logLik", "AIC", "BIC", "deviance", "df.residual"))
+    expect_equal(names(gnm), c("nobs", "sigma", "logLik", "AIC", "BIC", "deviance", "df.residual"))
     td <- tidy(nm)
     expect_equal(
       names(td),
@@ -156,7 +156,7 @@ context("lme4 models")
 
   test_that("glance works on lme4 fits", {
     g <- broom::glance(fit)
-    expect_equal(dim(g), c(1, 6))
+    expect_equal(dim(g), c(1, 7))
   })
 
   test_that("ran_vals works", {


### PR DESCRIPTION
NOTE: The experimental replacement for `finish_glance()`, `f2()`, is also
    updated with a 'nobs' column.

This addresses #71 which is specific to lme4 tidiers.

I've updated and run the tests to no failures and run `devtools::check()` to no errors, though i do not have most of the other suggested packages installed.

(I apologize for committing this change to `master` before creating the new branch, though i don't think it matters to the mechanics of the pull request.)