### PR TITLE
Add some basic testing of tidy.lme() confidence interval arguments

### DIFF
--- a/R/nlme_tidiers.R
+++ b/R/nlme_tidiers.R
@@ -232,6 +232,8 @@ tidy.lme <- function(x, effects = c("var_model", "ran_pars", "fixed"),
           ci$conf.low <- ci$conf.high <- NA
         }
         ## FIXME: also do confint on residual
+        ## (Once FIXED, also FIX the test "tidy works on nlme/lme fits" in test
+        ## file tests/testthat/test-nlme.R, see FIXME note in the test itself).
         ret <- dplyr::full_join(ret, ci, by = c("group", "term"))
       }
     } ## if not multi-level model

--- a/tests/testthat/test-nlme.R
+++ b/tests/testthat/test-nlme.R
@@ -21,6 +21,26 @@ if (suppressPackageStartupMessages(require(nlme, quietly = TRUE))) {
         "std.error", "df", "statistic", "p.value"
       )
     )
+    td_ci <- tidy(fit, conf.int = TRUE)
+    expect_equal(
+      names(td_ci),
+      c(
+          "effect", "group", "term", "estimate",
+          "std.error", "df", "statistic", "p.value",
+          "conf.low", "conf.high"
+      )
+    )
+    expect_equal(nrow(td_ci), 12)
+    td_ci_95 <- tidy(fit, conf.int = TRUE, conf.level = 0.95)
+    td_ci_25 <- tidy(fit, conf.int = TRUE, conf.level = 0.25)
+    cols_ci <- c("conf.low", "conf.high")
+    cols_other <- names(td_ci_95)[!names(td_ci_95) %in% cols_ci]
+    expect_identical(td_ci_95[, cols_other], td_ci_25[, cols_other])
+    # FIXME: remove [1:11] subsetting in the two lines below once conf.int for
+    # ran_pars Residual is implemented (see "FIXME: also do confint on
+    # residual" in source file R/nlme_tidiers.R).
+    expect_true(all(td_ci_95[["conf.low"]][1:11] < td_ci_25[["conf.low"]][1:11]))
+    expect_true(all(td_ci_95[["conf.high"]][1:11] > td_ci_25[["conf.high"]][1:11]))
   })
 
   test_that("tidy works on non-linear fits", {
@@ -50,6 +70,22 @@ if (suppressPackageStartupMessages(require(nlme, quietly = TRUE))) {
           "std.error", "df", "statistic", "p.value"
       )
     )
+    td_ci <- tidy(fm1, "fixed", conf.int = TRUE)
+    expect_equal(
+      names(td_ci),
+      c(
+          "effect", "term", "estimate",
+          "std.error", "df", "statistic", "p.value",
+          "conf.low", "conf.high"
+      )
+    )
+    td_ci_95 <- tidy(fm1, "fixed", conf.int = TRUE, conf.level = 0.95)
+    td_ci_25 <- tidy(fm1, "fixed", conf.int = TRUE, conf.level = 0.25)
+    cols_ci <- c("conf.low", "conf.high")
+    cols_other <- names(td_ci_95)[!names(td_ci_95) %in% cols_ci]
+    expect_identical(td_ci_95[, cols_other], td_ci_25[, cols_other])
+    expect_true(all(td_ci_95[["conf.low"]] < td_ci_25[["conf.low"]]))
+    expect_true(all(td_ci_95[["conf.high"]] > td_ci_25[["conf.high"]]))
   })
 
   test_that("augment works on lme fits with or without data", {


### PR DESCRIPTION
This PR is to add some basic testing of the fix introduced in PR #133.

The added tests check that the output from `tidy.lme()` called with `conf.int = TRUE` has the expected number of columns, with the expected column names. They also check that using `conf.level = 0.95` and `conf.level = 0.25` gives wider confidence intervals for 0.95 than for 0.25.

The tests are run both for a linear model and for a non-linear model. For the linear model test of confidence intervals, there is a small hack to go around the fact that there are no confidence intervals reported for the residual variance. I added a `FIXME` note at this location of the test file, referring to an already existing `FIXME` note in `R/nlme_tidiers.R` (existing note was: "FIXME: also do confint on residual"), so that one can remember to update the test when the `FIXME` in `nlme_tidiers.R` is addressed.

I hope this doesn't make the updated test file too confusing! Please let me know if you think I should address the absence of confint for residual variance in a different way, and I'll be happy to update the PR :)