### PR TITLE
Fix location of closing ) in across()

### DIFF
--- a/R/brms_tidiers.R
+++ b/R/brms_tidiers.R
@@ -280,7 +280,7 @@ tidy.brmsfit <- function(x, parameters = NA,
   if (exponentiate) {
     vv <- c("estimate", "conf.low", "conf.high")
     out <- (out
-      %>% mutate(across(contains(vv)), exp)
+      %>% mutate(across(contains(vv), exp))
       %>% mutate(across(std.error, ~ . * estimate))
     )
   }


### PR DESCRIPTION
The closing `)` for `across()` when exponentiating is currently accidentally after `contains(vv)`, leading to this error:

```
Error in `mutate()`:
! Problem while computing `..2 = exp`.
✖ `..2` must be a vector, not a primitive function.
Backtrace:
 1. model_logit_example %>% broom.mixed::tidy(exponentiate = TRUE)
 7. dplyr:::mutate.data.frame(., across(contains(vv)), exp)
```

This fixes it